### PR TITLE
Retry timings flag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytest-retry"
-version = "1.0.1"
+version = "1.0.2"
 description = "Adds the ability to retry flaky tests in CI environments"
 readme = "README.md"
 authors = [{ name = "str0zzapreti" }]

--- a/pytest_retry/__init__.py
+++ b/pytest_retry/__init__.py
@@ -1,0 +1,3 @@
+from .retry_plugin import success_key, attempts_key
+
+__all__ = ('success_key', 'attempts_key')

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,0 @@
-from setuptools import setup
-
-if __name__ == '__main__':
-    setup()

--- a/tests/test_retry_plugin.py
+++ b/tests/test_retry_plugin.py
@@ -49,7 +49,7 @@ def test_no_retry_on_skip_mark(testdir):
     testdir.makepyfile(
         """
         import pytest
-        @pytest.mark.skip(reason='do not run me')
+        @pytest.mark.skip(reason="do not run me")
         def test_skip():
             assert 1 == 1
         """
@@ -105,7 +105,7 @@ def test_retry_fails_after_consistent_setup_failure(testdir):
     testdir.makeconftest(
         """
         def pytest_runtest_setup(item):
-            raise Exception('Setup failure')
+            raise Exception("Setup failure")
         """
     )
     result = testdir.runpytest("--retries", "1")
@@ -122,7 +122,8 @@ def test_retry_passes_after_temporary_setup_failure(testdir):
         def pytest_runtest_setup(item):
             a.append(1)
             if len(a) < 2:
-                raise ValueError('Setup failed!')"""
+                raise ValueError("Setup failed!")
+        """
     )
     result = testdir.runpytest("--retries", "1")
 
@@ -231,26 +232,158 @@ def test_retry_delay_from_command_line_between_attempts(testdir):
             assert len(a) > 2
         """
     )
-    result = testdir.runpytest('--retries', '2', '--retry-delay', '2')
+    result = testdir.runpytest("--retries", "2", "--retry-delay", "2")
 
     assert_outcomes(result, passed=1, retried=1)
     assert result.duration > 4
 
 
-def test_report_is_available_from_item(testdir):
+def test_passing_outcome_is_available_from_item_stash(testdir):
     testdir.makepyfile(
         "def test_success(): assert 1 == 1"
     )
     testdir.makeconftest(
         """
         import pytest
+        from pytest_retry import success_key
 
         @pytest.fixture(autouse=True)
         def report_check(request):
             yield
-            assert request.node.report.outcome == 'passed'
+            assert request.node.stash[success_key] is True
         """
     )
     result = testdir.runpytest()
 
     assert_outcomes(result, passed=1)
+
+
+def test_failed_outcome_is_available_from_item_stash(testdir):
+    testdir.makepyfile(
+        "def test_success(): assert 1 == 2"
+    )
+    testdir.makeconftest(
+        """
+        import pytest
+        from pytest_retry import success_key
+
+        @pytest.fixture(autouse=True)
+        def report_check(request):
+            yield
+            assert request.node.stash[success_key] is False
+        """
+    )
+    result = testdir.runpytest()
+
+    assert_outcomes(result, passed=0, failed=1)
+
+
+def test_failed_outcome_after_successful_teardown(testdir):
+    testdir.makepyfile(
+        "def test_success(): assert 1 == 2"
+    )
+    testdir.makeconftest(
+        """
+        import pytest
+        from pytest_retry import success_key
+
+        @pytest.fixture(autouse=True)
+        def report_check(request):
+            yield
+            assert 1 == 1
+
+        def pytest_sessionfinish(session: pytest.Session) -> None:
+            for item in session.items:
+                assert item.stash[success_key] is False
+        """
+    )
+    result = testdir.runpytest()
+
+    assert_outcomes(result, passed=0, failed=1)
+
+
+def test_attempts_are_available_from_item_stash(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+
+        a = []
+
+        @pytest.mark.flaky(retries=2)
+        def test_eventually_passes():
+            a.append(1)
+            assert len(a) > 2
+        """
+    )
+    testdir.makeconftest(
+        """
+        import pytest
+        from pytest_retry import attempts_key
+
+        def pytest_sessionfinish(session: pytest.Session) -> None:
+            for item in session.items:
+                assert item.stash[attempts_key] == 3
+        """
+    )
+    result = testdir.runpytest()
+
+    assert_outcomes(result, passed=1, retried=1)
+
+
+def test_duration_in_overwrite_timings_mode(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+        from time import sleep
+
+        a = []
+
+        @pytest.mark.flaky(retries=2)
+        def test_eventually_passes():
+            sleep(2 - len(a))
+            a.append(1)
+            assert len(a) > 1
+        """
+    )
+    testdir.makeconftest(
+        """
+        import pytest
+        from pytest_retry import attempts_key
+
+        def pytest_report_teststatus(report: pytest.TestReport):
+            if report.when == "call" and report.outcome != "retried":
+                assert report.duration < 2
+        """
+    )
+    result = testdir.runpytest()
+
+    assert_outcomes(result, passed=1, retried=1)
+
+
+def test_duration_in_cumulative_timings_mode(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+        from time import sleep
+
+        a = []
+
+        def test_eventually_passes():
+            sleep(2 - len(a))
+            a.append(1)
+            assert len(a) > 1
+        """
+    )
+    testdir.makeconftest(
+        """
+        import pytest
+        from pytest_retry import attempts_key
+
+        def pytest_report_teststatus(report: pytest.TestReport):
+            if report.when == "call" and report.outcome != "retried":
+                assert report.duration > 3
+        """
+    )
+    result = testdir.runpytest("--retries", "2", "--cumulative-timing", "1")
+
+    assert_outcomes(result, passed=1, retried=1)


### PR DESCRIPTION
Added a new flag to select from two different duration modes. The default is now overwrite, where the last run's duration is written to the final report and all other attempt durations are discarded. This should help with time-based splitting algorithms such as CircleCI's and result in more even splits for fully passing runs. 

The original behavior is now available by passing the 'cumulative' option to the flag instead

Additionally, attaching arbitrary attributes to the test item is frowned upon in the Pytest docs, so instead, two new stash keys have been created to store and retrieve each item's attempt count and whether it passed or failed. These two values can be used to determine the outcome matrix for any test item: i.e. whether it passed, failed, passed with retries or failed with retries. 

New unit tests have been added to validate the additional functionality. 