### PR TITLE
bugfix: fix stash errors triggered by exceptions during teardown

### DIFF
--- a/pytest_retry/retry_plugin.py
+++ b/pytest_retry/retry_plugin.py
@@ -5,6 +5,7 @@ from io import StringIO
 from traceback import format_exception
 from typing import Generator, Optional
 from _pytest.terminal import TerminalReporter
+from _pytest.logging import caplog_records_key
 
 
 success_key = pytest.StashKey[bool]()
@@ -141,6 +142,8 @@ def pytest_runtest_makereport(
                 test_name=item.name,
                 err=t_exc_info,
             )
+            # Prevents a KeyError when an error during retry teardown causes a redundant teardown
+            item.stash[caplog_records_key] = {}  # type: ignore
             break
 
         if item.stash[attempts_key] == 1:


### PR DESCRIPTION
When an exception occurs during the teardown phase for a test, the current implementation of the plugin causes the teardown to be re-initiated by the surrounding testrunner. The fixture stack is already empty, so the only process which actually occurs during the second teardown is storage of two objects in the item stash, one of which requires an existing key already present in the stash. The first teardown causes the key to be deleted, hence the KeyError during the second stash

Two possible methods for resolving this:
1. Intercept after teardown instead of after call. That way, one teardown has already run correctly and I can essentially re-run the entire test session in order (instead of going teardown > setup > call). If there's a crash, my plugin won't re-run the teardown. The issue with this is it makes class and module level fixtures unusable. I would need to potentially find some way of tearing  them down after a teardown has already run, which runs into the same issue as my plugin currently.

2. Add dummy stash values. Technically, the stack for the item is already removed by the first teardown so the main thing the second teardown is doing is trying to hit the stash (it doesn't re-run fixtures). Definitely a less clean way of doing things and it might have further consequences that I can't predict.