### PR TITLE
feature: improve simple test reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,9 +133,9 @@ Tests which have been retried but eventually pass are counted as both retried an
 passed, and tests which have been retried but eventually fail are counted as both
 retried and failed. Skipped, xfailed, and xpassed tests are never retried.
 
-Two pytest stash keys are available to import from the pytest_retry plugin:
-`attempts_key` and `success_key`. These keys are used by the plugin to store the
-number of attempts each item has undergone and whether or not the test passed or
-failed, respectively. (If any stage of setup, call, or teardown fails, a test is
-considered failed overall). These stash keys can be used to retreive these reports
-for use in your own hooks or plugins.
+Three pytest stash keys are available to import from the pytest_retry plugin:
+`attempts_key`, `outcome_key`, and `duration_key`. These keys are used by the plugin
+to store the number of attempts each item has undergone, whether the test passed or
+failed, and the total duration from setup to teardown, respectively. (If any stage of 
+setup, call, or teardown fails, a test is considered failed overall). These stash keys 
+can be used to retrieve these reports for use in your own hooks or plugins.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytest-retry"
-version = "1.1.0"
+version = "1.2.0"
 description = "Adds the ability to retry flaky tests in CI environments"
 readme = "README.md"
 authors = [{ name = "str0zzapreti" }]
@@ -37,3 +37,8 @@ pytest-retry = "pytest_retry.retry_plugin"
 python_version = "3.10"
 cache_dir = "/dev/null"
 disallow_untyped_defs = true
+
+[tool.black]
+line-length = 99
+target-version = ['py310']
+fast = true

--- a/pytest_retry/__init__.py
+++ b/pytest_retry/__init__.py
@@ -1,3 +1,3 @@
-from .retry_plugin import success_key, attempts_key
+from .retry_plugin import duration_key, outcome_key, attempts_key
 
-__all__ = ('success_key', 'attempts_key')
+__all__ = ("duration_key", "outcome_key", "attempts_key")

--- a/pytest_retry/retry_plugin.py
+++ b/pytest_retry/retry_plugin.py
@@ -8,8 +8,10 @@ from _pytest.terminal import TerminalReporter
 from _pytest.logging import caplog_records_key
 
 
-success_key = pytest.StashKey[bool]()
+outcome_key = pytest.StashKey[str]()
 attempts_key = pytest.StashKey[int]()
+duration_key = pytest.StashKey[float]()
+stages = ("setup", "call", "teardown")
 
 
 class RetryHandler:
@@ -21,32 +23,25 @@ class RetryHandler:
     def __init__(self) -> None:
         self.stream = StringIO()
         self.trace_limit: Optional[int] = -1
+        self.node_stats: dict[str, dict] = {}
 
     def log_test_retry(self, attempt: int, test_name: str, err: tuple) -> None:
         formatted_trace = (
-            "".join(format_exception(*err, limit=self.trace_limit))
-            .replace("\n", "\n\t")
-            .rstrip()
+            "".join(format_exception(*err, limit=self.trace_limit)).replace("\n", "\n\t").rstrip()
         )
         message = f" failed on attempt {attempt}! Retrying!\n\t"
         self.stream.writelines([f"\t{test_name}", message, formatted_trace, "\n\n"])
 
     def log_test_totally_failed(self, attempt: int, test_name: str, err: tuple) -> None:
         formatted_trace = (
-            "".join(format_exception(*err, limit=self.trace_limit))
-            .replace("\n", "\n\t")
-            .rstrip()
+            "".join(format_exception(*err, limit=self.trace_limit)).replace("\n", "\n\t").rstrip()
         )
         message = f" failed after {attempt} attempts!\n\t"
         self.stream.writelines([f"\t{test_name}", message, formatted_trace, "\n\n"])
 
-    def log_test_finalizer_failed(
-        self, attempt: int, test_name: str, err: tuple
-    ) -> None:
+    def log_test_finalizer_failed(self, attempt: int, test_name: str, err: tuple) -> None:
         formatted_trace = (
-            "".join(format_exception(*err, limit=self.trace_limit))
-            .replace("\n", "\n\t")
-            .rstrip()
+            "".join(format_exception(*err, limit=self.trace_limit)).replace("\n", "\n\t").rstrip()
         )
         message = f" finalizer failed on attempt {attempt}! Exiting immediately!\n\t"
         self.stream.writelines([f"\t{test_name}", message, formatted_trace, "\n\n"])
@@ -61,10 +56,38 @@ class RetryHandler:
             "the following tests were retried", sep="=", bold=True, yellow=True
         )
         terminalreporter.write(contents)
-        terminalreporter.section(
-            "end of test retry report", sep="=", bold=True, yellow=True
-        )
+        terminalreporter.section("end of test retry report", sep="=", bold=True, yellow=True)
         terminalreporter.write("\n")
+
+    def record_node_stats(self, report: pytest.TestReport) -> None:
+        self.node_stats[report.nodeid]["outcomes"][report.when].append(report.outcome)
+        self.node_stats[report.nodeid]["durations"][report.when].append(report.duration)
+
+    def simple_outcome(self, item: pytest.Item) -> str:
+        """
+        Return failed if setup, teardown, or final call outcome is 'failed'
+        Return skipped if test was skipped
+        """
+        test_outcomes = self.node_stats[item.nodeid]["outcomes"]
+        for outcome in ("skipped", "failed"):
+            if outcome in test_outcomes["setup"]:
+                return outcome
+        if not test_outcomes["call"] or test_outcomes["call"][-1] == "failed":
+            return "failed"
+        if "failed" in test_outcomes["teardown"]:
+            return "failed"
+        return "passed"
+
+    def simple_duration(self, item: pytest.Item) -> float:
+        """
+        Return total duration for test summing setup, teardown, and final call
+        """
+        if not self.node_stats[item.nodeid]["durations"]["call"]:
+            return 0.0
+        return sum(self.node_stats[item.nodeid]["durations"][stage][-1] for stage in stages)
+
+    def sum_attempts(self, item: pytest.Item) -> int:
+        return len(self.node_stats[item.nodeid]["outcomes"]["call"])
 
 
 retry_manager = RetryHandler()
@@ -85,6 +108,9 @@ def should_handle_retry(rep: pytest.TestReport) -> bool:
     # if test passed, don't retry
     if rep.passed:
         return False
+    # if teardown stage, don't retry
+    if rep.when == "teardown":
+        return False
     # if test was skipped, don't retry
     if rep.skipped:
         return False
@@ -94,17 +120,27 @@ def should_handle_retry(rep: pytest.TestReport) -> bool:
     return True
 
 
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_protocol(item: pytest.Item) -> Optional[object]:
+    retry_manager.node_stats[item.nodeid] = {
+        "outcomes": {k: [] for k in stages},
+        "durations": {k: [] for k in stages},
+    }
+    yield
+    item.stash[outcome_key] = retry_manager.simple_outcome(item)
+    item.stash[duration_key] = retry_manager.simple_duration(item)  # always overwrite, for now
+    item.stash[attempts_key] = retry_manager.sum_attempts(item)
+
+
 @pytest.hookimpl(hookwrapper=True, tryfirst=True)
 def pytest_runtest_makereport(
     item: pytest.Item, call: pytest.CallInfo
 ) -> Generator[None, pytest.TestReport, None]:
     outcome = yield
     original_report: pytest.TestReport = outcome.get_result()
-    # Attach outcome and attempts to item. If any stage failed, the test is considered failed
-    if original_report.when == 'teardown':
-        return
-    item.stash[success_key] = original_report.passed
-    item.stash[attempts_key] = 1
+    retry_manager.record_node_stats(original_report)
+    # Set dynamic outcome for each stage until runtest protocol has completed.
+    item.stash[outcome_key] = original_report.outcome
     if not should_handle_retry(original_report):
         return
     flake_mark = item.get_closest_marker("flaky")
@@ -115,6 +151,7 @@ def pytest_runtest_makereport(
     timing = flake_mark.kwargs.get("timing", "overwrite")
     if timing not in ("overwrite", "cumulative"):
         raise ValueError(f"Unknown timing type: {timing}! Must be `cumulative` or `overwrite`.")
+    attempts = 1
     hook = item.ihook
 
     while True:
@@ -122,8 +159,8 @@ def pytest_runtest_makereport(
         exc_info = (call.excinfo.type, call.excinfo.value, call.excinfo.tb)  # type: ignore
         if call.when == "setup":
             break  # will handle fixture setup retries in v2, if necessary. For now, this is fine.
-        # Teardowns are already excluded, so this must be the `call` stage
-        # Try teardown test teardown using a fake item to ensure every local fixture (i.e.
+        # Default teardowns are already excluded, so this must be the `call` stage
+        # Try preliminary teardown using a fake item to ensure every local fixture (i.e.
         # excluding session) is torn down. Yes, including module and class fixtures
         t_call = pytest.CallInfo.from_call(
             lambda: hook.pytest_runtest_teardown(
@@ -134,9 +171,10 @@ def pytest_runtest_makereport(
         )
         # If teardown fails, break. Flaky teardowns are not acceptable and should raise immediately
         if t_call.excinfo:
+            item.stash[outcome_key] = 'failed'
             t_exc_info = (t_call.excinfo.type, t_call.excinfo.value, t_call.excinfo.tb)
             retry_manager.log_test_finalizer_failed(
-                attempt=item.stash[attempts_key],
+                attempt=attempts,
                 test_name=item.name,
                 err=t_exc_info,
             )
@@ -144,12 +182,13 @@ def pytest_runtest_makereport(
             item.stash[caplog_records_key] = {}  # type: ignore
             break
 
-        if item.stash[attempts_key] == 1:
-            # The test only needs to report that it is being retried the first time
-            original_report.outcome = "retried"  # type: ignore[assignment]
-            item.ihook.pytest_runtest_logreport(report=original_report)
+        # If teardown passes, send report that the test is being retried
+        if attempts == 1:
+            original_report.retried = True  # type: ignore[attr-defined]
+            hook.pytest_runtest_logreport(report=original_report)
+            del original_report.retried
         retry_manager.log_test_retry(
-            attempt=item.stash[attempts_key], test_name=item.name, err=exc_info
+            attempt=attempts, test_name=item.name, err=exc_info
         )
         sleep(delay)
         # Call _initrequest(). Only way to get the setup to run again
@@ -158,27 +197,27 @@ def pytest_runtest_makereport(
         pytest.CallInfo.from_call(lambda: hook.pytest_runtest_setup(item=item), when="setup")
         call = pytest.CallInfo.from_call(lambda: hook.pytest_runtest_call(item=item), when="call")
         retry_report = pytest.TestReport.from_item_and_call(item, call)
+        retry_manager.record_node_stats(retry_report)
         # Do the exception interaction step
         # (may not bother to support this since this is designed for automated runs, not debugging)
         if has_interactive_exception(call):
             hook.pytest_exception_interact(node=item, call=call, report=retry_report)
 
-        item.stash[attempts_key] += 1
-        should_keep_retrying = not retry_report.passed and item.stash[attempts_key] <= retries
+        attempts += 1
+        should_keep_retrying = not retry_report.passed and attempts <= retries
 
         if not should_keep_retrying:
             original_report.outcome = retry_report.outcome
             original_report.longrepr = retry_report.longrepr
-            if timing == 'overwrite':
+            if timing == "overwrite":
                 original_report.duration = retry_report.duration
             else:
                 original_report.duration += retry_report.duration
-            item.stash[success_key] = retry_report.passed
 
             if retry_report.failed:
                 exc_info = (call.excinfo.type, call.excinfo.value, call.excinfo.tb)  # type: ignore
                 retry_manager.log_test_totally_failed(
-                    attempt=item.stash[attempts_key], test_name=item.name, err=exc_info
+                    attempt=attempts, test_name=item.name, err=exc_info
                 )
             break
 
@@ -190,7 +229,7 @@ def pytest_terminal_summary(terminalreporter: TerminalReporter) -> None:
 def pytest_report_teststatus(
     report: pytest.TestReport,
 ) -> Optional[tuple[str, str, tuple[str, dict]]]:
-    if report.outcome == "retried":
+    if hasattr(report, "retried"):
         return "retried", "R", ("RETRY", {"yellow": True})
     return None
 
@@ -202,7 +241,7 @@ def pytest_configure(config: pytest.Config) -> None:
         "will be retried the number of times specified with an"
         "(optional) specified delay between each attempt",
     )
-    if config.getoption('verbose'):
+    if config.getoption("verbose"):
         # if pytest config has -v enabled, then don't limit traceback length
         retry_manager.trace_limit = None
 
@@ -237,9 +276,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     )
 
 
-def pytest_collection_modifyitems(
-    config: pytest.Config, items: list[pytest.Item]
-) -> None:
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
     if not config.getoption("--retries"):
         return
     retry_delay = config.getoption("--retry-delay") or 0


### PR DESCRIPTION
Overhauls the internal reporting system to make more detailed information about the test state available during and after the runtest protocol. Initially, items only stored a simple True/False value for success key and a count for the total number of attempts. Now, items store a str outcome which can be passed, failed, or skipped. A new duration key has also been added which enables easy access to test duration from hooks (note: duration is only calculated after item teardown has been completed and is not accessible sooner). 

Possible future changes: a rolling sum for duration to enable partial reporting (e.g. make duration available when only setup or setup and call have completed)

Added some new tests to cover the additional changes