### PR TITLE
hotfixed retry failure count

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytest-retry"
-version = "1.2.0"
+version = "1.2.1"
 description = "Adds the ability to retry flaky tests in CI environments"
 readme = "README.md"
 authors = [{ name = "str0zzapreti" }]

--- a/tests/test_retry_plugin.py
+++ b/tests/test_retry_plugin.py
@@ -296,7 +296,7 @@ def test_skipped_outcome_is_available_from_item_stash(testdir):
             for item in session.items:
                 assert item.stash[outcome_key] == "skipped"
                 assert item.stash[attempts_key] == 0
-                assert item.stash[duration_key] == 0.0
+                assert item.stash[duration_key] < 0.1
         """
     )
     result = testdir.runpytest()
@@ -462,7 +462,7 @@ def test_duration_in_overwrite_timings_mode(testdir):
         from pytest_retry import attempts_key
 
         def pytest_report_teststatus(report: pytest.TestReport):
-            if report.when == "call" and not hasattr(report, "retried"):
+            if report.when == "call" and report.outcome != "retried":
                 assert report.duration < 2
         """
     )
@@ -491,7 +491,7 @@ def test_duration_in_cumulative_timings_mode(testdir):
         from pytest_retry import attempts_key
 
         def pytest_report_teststatus(report: pytest.TestReport):
-            if report.when == "call" and not hasattr(report, "retried"):
+            if report.when == "call" and report.outcome != "retried":
                 assert report.duration > 3
         """
     )


### PR DESCRIPTION
Turns out using attributes for the report to track retries doesn't work with Pytest's internal counter. The outcome has to be overwritten even though it's got a Literal typing for passed, failed, and skipped. The other official retry plugins do this as well. Seems rather strange, but there it is.

Also prevented a possible durations index error if another exception occurred during the pytest_report_teststatus stage. (e.g. if using a custom teststatus hook in conjunction with this plugin). 