### PR TITLE
added condition arg for flaky mark

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,18 @@ def test_unreliable_service():
     ...
 ```
 
+If you want some other generalized condition to control whether a test is retried, use the
+`condition` argument. Any statement which results in a bool can be used here to add granularity
+to your retries. The test will only be retried if `condition` is `True`. Note, there is no
+matching command line option for `condition`, but if you need to globally apply this type of logic
+to all of your tests, consider invoking the `pytest_collection_modifyitems` hook.
+
+```
+@pytest.mark.flaky(retries=2, condition=sys.platform.startswith('win32'))
+def test_only_flaky_on_some_systems():
+    # This test will only be retried if sys.platform.startswith('win32') evaluates to `True`
+```
+
 Finally, there is a flaky mark argument for the test timing method, which can either
 be `overwrite` (default) or `cumulative`. See **Command Line** > **Advanced Options** 
 for more information

--- a/tests/test_retry_plugin.py
+++ b/tests/test_retry_plugin.py
@@ -677,3 +677,33 @@ def test_duration_in_cumulative_timings_mode(testdir):
     result = testdir.runpytest("--retries", "2", "--cumulative-timing", "1")
 
     assert_outcomes(result, passed=1, retried=1)
+
+
+def test_conditional_flaky_marks_evaluate_correctly(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+
+        a = []
+        b = []
+        c = []
+
+        @pytest.mark.flaky(retries=2, condition=True)
+        def test_eventually_passes():
+            a.append(1)
+            assert len(a) > 2
+
+        @pytest.mark.flaky(retries=2, condition=True)
+        def test_eventually_passes_again():
+            b.append(1)
+            assert len(b) > 2
+
+        @pytest.mark.flaky(retries=2, condition=False)
+        def test_eventually_passes_once_more():
+            c.append(1)
+            assert len(c) > 2
+        """
+    )
+    result = testdir.runpytest()
+
+    assert_outcomes(result, passed=2, failed=1, retried=2)


### PR DESCRIPTION
the flaky mark now has an additional arg `condition` which enables further control over when tests are retried based on generic conditionals.
Updated documentation to include the new arg
Added a test to validate new functionality