### PR TITLE
removed _initrequest call from item and updated comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ thereby improving the consistency of the test suite results.
 ## Requirements
 
 pytest-retry is designed for the latest versions of Python and Pytest. Python 3.9+
-and pytest 7.0.0 are required. 
+and pytest 7.0.0+ are required. 
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytest-retry"
-version = "1.5.0"
+version = "1.5.1b"
 description = "Adds the ability to retry flaky tests in CI environments"
 readme = "README.md"
 authors = [{ name = "str0zzapreti" }]

--- a/pytest_retry/retry_plugin.py
+++ b/pytest_retry/retry_plugin.py
@@ -2,6 +2,7 @@ import pytest
 import bdb
 from time import sleep
 from io import StringIO
+from logging import LogRecord
 from traceback import format_exception
 from typing import Generator, Optional
 from collections.abc import Iterable
@@ -208,7 +209,8 @@ def pytest_runtest_makereport(
                 attempt=attempts, name=item.name, exc=t_call.excinfo, outcome=2
             )
             # Prevents a KeyError when an error during retry teardown causes a redundant teardown
-            item.stash[caplog_records_key] = {}  # type: ignore
+            empty: dict[str, list[LogRecord]] = {}
+            item.stash[caplog_records_key] = empty
             break
 
         # If teardown passes, send report that the test is being retried

--- a/pytest_retry/retry_plugin.py
+++ b/pytest_retry/retry_plugin.py
@@ -120,9 +120,7 @@ retry_manager = RetryHandler()
 
 
 def has_interactive_exception(call: pytest.CallInfo) -> bool:
-    # Check whether the call raised an exception that should be reported as interactive.
     if call.excinfo is None:
-        # Didn't raise.
         return False
     if isinstance(call.excinfo.value, bdb.BdbQuit):
         # Special control flow exception.
@@ -162,7 +160,7 @@ def pytest_runtest_makereport(
     outcome = yield
     original_report: pytest.TestReport = outcome.get_result()
     retry_manager.record_node_stats(original_report)
-    # Set dynamic outcome for each stage until runtest protocol has completed.
+    # Set dynamic outcome for each stage until runtest protocol has completed
     item.stash[outcome_key] = original_report.outcome
 
     if not should_handle_retry(call):
@@ -203,7 +201,7 @@ def pytest_runtest_makereport(
             ),
             when="teardown",
         )
-        # If teardown fails, break. Flaky teardowns are not acceptable and should raise immediately
+        # If teardown fails, break. Flaky teardowns are unacceptable and should raise immediately
         if t_call.excinfo:
             item.stash[outcome_key] = "failed"
             retry_manager.log_attempt(
@@ -220,8 +218,6 @@ def pytest_runtest_makereport(
             original_report.outcome = "failed"
         retry_manager.log_attempt(attempt=attempts, name=item.name, exc=call.excinfo, outcome=0)
         sleep(delay)
-        # Call _initrequest(). Only way to get the setup to run again
-        item._initrequest()  # type: ignore[attr-defined]
 
         pytest.CallInfo.from_call(lambda: hook.pytest_runtest_setup(item=item), when="setup")
         call = pytest.CallInfo.from_call(lambda: hook.pytest_runtest_call(item=item), when="call")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pytest>=7.1.2
+pytest>=7.0.0
 black>=23.3.0
 mypy>=1.3.0

--- a/tests/test_retry_plugin.py
+++ b/tests/test_retry_plugin.py
@@ -271,7 +271,7 @@ def test_retry_delay_from_command_line_between_attempts(testdir):
 
     assert_outcomes(result, passed=1, retried=1)
     assert result.duration > 0.4
-    assert result.duration < 0.7
+    assert result.duration < 0.8
 
 
 def test_passing_outcome_is_available_from_item_stash(testdir):
@@ -731,7 +731,7 @@ def test_configuration_by_pyproject_toml_file(testdir):
 
     assert_outcomes(result, passed=0, failed=1, retried=1)
     assert result.duration > 0.3
-    assert result.duration < 0.6
+    assert result.duration < 0.7
 
 
 def test_duration_in_overwrite_timings_mode(testdir):


### PR DESCRIPTION
Performing some unrelated testing for xdist compatibility and noticed that this _initrequest() method call isn't necessary for the tests to pass, even with the older pytest 7 version I built this plugin on. I wasn't aware of the API changing and I distinctly remember being annoyed that I was unable to reset item fixtures without this call, so for now this will go out in a beta release until I'm certain it's actually unnecessary. 