### PR TITLE
added test coverage to prevent fixture retry regressions.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytest-retry"
-version = "1.5.1b"
+version = "1.5.1"
 description = "Adds the ability to retry flaky tests in CI environments"
 readme = "README.md"
 authors = [{ name = "str0zzapreti" }]

--- a/pytest_retry/retry_plugin.py
+++ b/pytest_retry/retry_plugin.py
@@ -220,6 +220,8 @@ def pytest_runtest_makereport(
             original_report.outcome = "failed"
         retry_manager.log_attempt(attempt=attempts, name=item.name, exc=call.excinfo, outcome=0)
         sleep(delay)
+        # Calling _initrequest() is required to reset fixtures for a retry. Make public pls?
+        item._initrequest()  # type: ignore[attr-defined]
 
         pytest.CallInfo.from_call(lambda: hook.pytest_runtest_setup(item=item), when="setup")
         call = pytest.CallInfo.from_call(lambda: hook.pytest_runtest_call(item=item), when="call")

--- a/tests/test_retry_plugin.py
+++ b/tests/test_retry_plugin.py
@@ -241,8 +241,8 @@ def test_fixtures_are_retried_with_test(testdir):
         def test_eventually_passes(basic_setup_and_teardown):
             a.append(1)
             assert len(a) > 2
-        
-        
+
+
         def test_setup_and_teardown_reran():
             assert len(setup) == 3
             assert len(teardown) == 3


### PR DESCRIPTION
Added a new test which validates that setup and teardown stages are properly executed with each retry. Pytest doesn't provide a public API for this so calling item._initrequest() is the only clear solution for now. 