### PR TITLE
Add reporting functionality when using pytest xdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytest-retry"
-version = "1.5.1"
+version = "1.6.0"
 description = "Adds the ability to retry flaky tests in CI environments"
 readme = "README.md"
 authors = [{ name = "str0zzapreti" }]

--- a/pytest_retry/retry_plugin.py
+++ b/pytest_retry/retry_plugin.py
@@ -104,7 +104,7 @@ class RetryHandler:
         if not test_outcomes["call"] or test_outcomes["call"][-1] == "failed":
             return "failed"
         if "failed" in test_outcomes["teardown"]:
-            return "failed"
+            return "failed"   # is there always a teardown? can probably just simplify this to return test_outcomes["teardown"] as a fallthrough
         return "passed"
 
     def simple_duration(self, item: pytest.Item) -> float:
@@ -281,6 +281,10 @@ def pytest_configure(config: pytest.Config) -> None:
     if config.getoption("verbose"):
         # if pytest config has -v enabled, then don't limit traceback length
         retry_manager.trace_limit = None
+    if not (hasattr(config, "workerinput")) or not (hasattr(config, "slaveinput")):
+        retry_manager.name = "mainboi"
+    else:
+        retry_manager.name = "clientboi"
     Defaults.configure(config)
     Defaults.add("FILTERED_EXCEPTIONS", config.hook.pytest_set_filtered_exceptions() or [])
     Defaults.add("EXCLUDED_EXCEPTIONS", config.hook.pytest_set_excluded_exceptions() or [])

--- a/pytest_retry/retry_plugin.py
+++ b/pytest_retry/retry_plugin.py
@@ -296,7 +296,7 @@ def pytest_configure(config: pytest.Config) -> None:
     Defaults.configure(config)
     Defaults.add("FILTERED_EXCEPTIONS", config.hook.pytest_set_filtered_exceptions() or [])
     Defaults.add("EXCLUDED_EXCEPTIONS", config.hook.pytest_set_excluded_exceptions() or [])
-    if config.getoption("numprocesses"):
+    if config.getoption("numprocesses", False):
         retry_manager.reporter = ReportServer()
     elif hasattr(config, "workerinput"):
         retry_manager.reporter = ClientReporter()

--- a/pytest_retry/server.py
+++ b/pytest_retry/server.py
@@ -7,7 +7,7 @@ CONN_PORT = 9009
 
 
 class ReportHandler:
-    def __init__(self):
+    def __init__(self) -> None:
         self.stream = StringIO()
 
     def build_retry_report(self, terminalreporter: TerminalReporter) -> None:
@@ -18,7 +18,7 @@ class ReportHandler:
 
 
 class OfflineReporter(ReportHandler):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
 
     def record_attempt(self, lines: list[str]) -> None:
@@ -26,7 +26,7 @@ class OfflineReporter(ReportHandler):
 
 
 class ReportServer(ReportHandler):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.sock.setblocking(True)
@@ -35,7 +35,7 @@ class ReportServer(ReportHandler):
         t = threading.Thread(target=self.run_server, daemon=True)
         t.start()
 
-    def run_server(self):
+    def run_server(self) -> None:
         self.sock.listen()
         while True:
             conn, _ = self.sock.accept()
@@ -48,7 +48,7 @@ class ReportServer(ReportHandler):
 
 
 class ClientReporter(ReportHandler):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.sock.setblocking(True)

--- a/pytest_retry/server.py
+++ b/pytest_retry/server.py
@@ -1,0 +1,73 @@
+import socket
+import threading
+from io import StringIO
+from _pytest.terminal import TerminalReporter
+
+# check if xdist installed (set min version to 1.20, don't worry about older compat)
+# Set xdist hooks if installed?
+# Look at pytest_configure_node
+# Set up two handlers, one for server and one for clients
+# server handler probably needs threading
+# Set up sockets with send and recieve. Might want to look at some docs on this
+# assign handler to rerun process based on server or client
+# When setting reports, client should send via socket while server should just set normally
+# server should also be set up to receive (via threading) and should log those entries as well
+
+
+# pieces:
+
+CONN_PORT = 0
+
+
+class ReportHandler:
+    def __init__(self):
+        self.stream = StringIO()
+
+    def generate_report(self, terminalreporter: TerminalReporter) -> None:
+        contents = self.stream.getvalue()
+        if not contents:
+            return
+
+        terminalreporter.write("\n")
+        terminalreporter.section(
+            "the following tests were retried", sep="=", bold=True, yellow=True
+        )
+        terminalreporter.write(contents)
+        terminalreporter.section("end of test retry report", sep="=", bold=True, yellow=True)
+        terminalreporter.write("\n")
+
+
+class ReportServer:
+    def __init__(self):
+        self.stream = StringIO()
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.sock.setblocking(True)
+        self.sock.bind(("localhost", CONN_PORT))
+        self.sock.listen()
+        while True:
+            conn, _ = self.sock.accept()
+            while True:
+                report_chunk = conn.recv(1024)
+                if not report_chunk:
+                    break
+                self.stream.write(report_chunk.decode())
+
+    def generate_report(self, terminalreporter: TerminalReporter) -> None:
+        terminalreporter.write("\n")
+        terminalreporter.section(
+            "the following tests were retried", sep="=", bold=True, yellow=True
+        )
+        terminalreporter.write(self.stream.getvalue())
+        terminalreporter.section("end of test retry report", sep="=", bold=True, yellow=True)
+        terminalreporter.write("\n")
+
+
+class ReportClient:
+    def __init__(self):
+        self.stream = StringIO()
+        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.sock.setblocking(True)
+
+    def generate_report(self, _) -> None:
+        self.sock.sendall(self.stream)

--- a/tests/test_retry_plugin.py
+++ b/tests/test_retry_plugin.py
@@ -787,7 +787,7 @@ def test_duration_in_overwrite_timings_mode(testdir):
 
         def pytest_report_teststatus(report: pytest.TestReport):
             if report.when == "call" and report.outcome != "retried":
-                assert report.duration < 0.6
+                assert report.duration < 0.7
         """
     )
     result = testdir.runpytest()

--- a/tests/test_retry_plugin.py
+++ b/tests/test_retry_plugin.py
@@ -1,7 +1,7 @@
 from pytest import mark
 
 try:
-    import xdist  # noqa: F401
+    from xdist import __version__  # noqa: F401
 
     xdist_installed = True
 except ImportError:

--- a/tests/test_retry_plugin.py
+++ b/tests/test_retry_plugin.py
@@ -1,7 +1,8 @@
 from pytest import mark
 
 try:
-    import xdist
+    import xdist  # noqa: F401
+
     xdist_installed = True
 except ImportError:
     xdist_installed = False


### PR DESCRIPTION
As noted in https://github.com/str0zzapreti/pytest-retry/issues/26, while pytest-retry is fully compatible with xdist from a test running standpoint, retry reports weren't displayed. Workers initialized from xdist don't call the terminal summary hook while the server doesn't run any tests, so nothing would output to the terminal.

Added a new server module and slightly refactored the RetryManager to store a report handler object rather than a simple StringIO stream. 

The new OfflineReporter is the default when running sequentially without xdist. It encapsulates the existing report behavior although a slight change is that successful attempts for retried tests are now logged.

A ReportServer and ClientReporter handle building the report when xdist is invoked with n > 1. ClientReporters collect retry logs for each test as a group and then stream them to the ReportServer over a local socket. The ReportServer listens for incoming logs and assembles a complete retry report out of the incoming chunks. This ensures that retry logs for each test are grouped together in the final report for better readability. Ordering w/r/t overall test execution may obviously not be maintained, but that shouldn't matter. 

Added a new test to validate that retry reports are output correctly when using xdist. Note that this test is not part of the normal pytest-retry CI suite for now and is mainly a tool for contributors to locally validate that their changes maintain compatibility with pytest-xdist. This is not a main priority.  

Some other miscellaneous fixes: Added constants to the retry results for better clarity when reviewing the code and made a few minor name changes. 