### PR TITLE
Added random free port assignment and sync to prevent port conflicts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytest-retry"
-version = "1.6.0"
+version = "1.6.1"
 description = "Adds the ability to retry flaky tests in CI environments"
 readme = "README.md"
 authors = [{ name = "str0zzapreti" }]

--- a/pytest_retry/retry_plugin.py
+++ b/pytest_retry/retry_plugin.py
@@ -3,7 +3,7 @@ import bdb
 from time import sleep
 from logging import LogRecord
 from traceback import format_exception
-from typing import Generator, Optional
+from typing import Any, Generator, Optional
 from collections.abc import Iterable
 from pytest_retry.configs import Defaults
 from pytest_retry.server import ReportHandler, OfflineReporter, ReportServer, ClientReporter
@@ -284,7 +284,7 @@ def pytest_report_teststatus(
 
 class XdistHook:
     @staticmethod
-    def pytest_configure_node(node):
+    def pytest_configure_node(node: Any) -> None:  # Xdist WorkerController instance
         # Tells each worker node which port was randomly assigned to the retry server
         node.workerinput["server_port"] = node.config.stash[server_port_key]
 

--- a/pytest_retry/retry_plugin.py
+++ b/pytest_retry/retry_plugin.py
@@ -309,7 +309,8 @@ def pytest_configure(config: pytest.Config) -> None:
         retry_manager.reporter = ReportServer()
         config.stash[server_port_key] = retry_manager.reporter.initialize_server()
     elif hasattr(config, "workerinput"):
-        retry_manager.reporter = ClientReporter(config.workerinput["server_port"])
+        # pytest-xdist doesn't use the config stash, so have to ignore a type error here
+        retry_manager.reporter = ClientReporter(config.workerinput["server_port"])  # type: ignore
 
 
 RETRIES_HELP_TEXT = "number of times to retry failed tests. Defaults to 0."


### PR DESCRIPTION
As per https://github.com/str0zzapreti/pytest-retry/issues/30, switched from fixed port assignment to letting the OS assign a random available port. This prevents a port conflict and resulting OSError which would occur if two test instances were run simultaneously on the same machine. 

Thanks @andrewasheridan for the suggestion.