### PR TITLE
fixed Item instantiation error in Pytest 8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytest-retry"
-version = "1.6.1"
+version = "1.6.2"
 description = "Adds the ability to retry flaky tests in CI environments"
 readme = "README.md"
 authors = [{ name = "str0zzapreti" }]

--- a/pytest_retry/retry_plugin.py
+++ b/pytest_retry/retry_plugin.py
@@ -204,12 +204,12 @@ def pytest_runtest_makereport(
 
     while True:
         # Default teardowns are already excluded, so this must be the `call` stage
-        # Try preliminary teardown using a fake item to ensure every local fixture (i.e.
+        # Try preliminary teardown using a fake class to ensure every local fixture (i.e.
         # excluding session) is torn down. Yes, including module and class fixtures
         t_call = pytest.CallInfo.from_call(
             lambda: hook.pytest_runtest_teardown(
                 item=item,
-                nextitem=pytest.Item.from_parent(item.session, name="fakeboi"),
+                nextitem=pytest.Class.from_parent(item.session, name="Fakeboi"),
             ),
             when="teardown",
         )

--- a/tests/test_retry_plugin.py
+++ b/tests/test_retry_plugin.py
@@ -260,6 +260,70 @@ def test_fixtures_are_retried_with_test(testdir):
     assert_outcomes(result, passed=2, failed=0, retried=1)
 
 
+def test_retry_executes_class_scoped_fixture(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+
+        a = []
+        setup = []
+        teardown = []
+
+        @pytest.fixture(scope="class")
+        def basic_setup_and_teardown():
+            setup.append(True)
+            yield
+            teardown.append(True)
+        
+        @pytest.mark.usefixtures("basic_setup_and_teardown")
+        class TestClassFixtures:
+            @pytest.mark.flaky(retries=2)
+            def test_eventually_passes(self):
+                a.append(1)
+                assert len(a) > 2
+    
+    
+        def test_setup_and_teardown_reran():
+            assert len(setup) == 3
+            assert len(teardown) == 3
+        """
+    )
+    result = testdir.runpytest()
+
+    assert_outcomes(result, passed=2, failed=0, retried=1)
+
+
+def test_retry_executes_module_scoped_fixture(testdir):
+    testdir.makepyfile(
+        """
+        import pytest
+
+        a = []
+        setup = []
+        teardown = []
+
+        @pytest.fixture(scope="module")
+        def basic_setup_and_teardown():
+            setup.append(True)
+            yield
+            teardown.append(True)
+
+        @pytest.mark.flaky(retries=2)
+        def test_eventually_passes(basic_setup_and_teardown):
+            a.append(1)
+            assert len(a) > 2
+
+
+        def test_setup_and_teardown_reran():
+            assert len(setup) == 3
+            assert len(teardown) == 2
+        """
+    )
+    result = testdir.runpytest()
+
+    assert_outcomes(result, passed=2, failed=0, retried=1)
+
+
 def test_retry_fails_if_temporary_failures_exceed_retry_limit(testdir):
     testdir.makepyfile(
         """

--- a/tests/test_retry_plugin.py
+++ b/tests/test_retry_plugin.py
@@ -274,15 +274,15 @@ def test_retry_executes_class_scoped_fixture(testdir):
             setup.append(True)
             yield
             teardown.append(True)
-        
+
         @pytest.mark.usefixtures("basic_setup_and_teardown")
         class TestClassFixtures:
             @pytest.mark.flaky(retries=2)
             def test_eventually_passes(self):
                 a.append(1)
                 assert len(a) > 2
-    
-    
+
+
         def test_setup_and_teardown_reran():
             assert len(setup) == 3
             assert len(teardown) == 3


### PR DESCRIPTION
- Changed finalizer to use a dummy Class to avoid ABC instantiation error 
- Pytest made this change in version 8.0 to enforce standards for their base classes 
- Added tests to validate fixture handling at class and module scope
- I find the chance of a name collision highly unlikely, but if requested I will add a note to the documentation instructing users to avoid naming any of their test classes 'Fakeboi' while using pytest-retry. I hope common sense will prevail.

Thanks to @adamtheturtle for highlighting this change and pushing an initial fix!
