### PR TITLE
feat: --max-global-retries option

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ setenv =
 deps =
     -r{toxinidir}/dev-requirements.txt
 commands =
-    pytest --basetemp={envtmpdir}
+    pytest --basetemp={envtmpdir} {posargs}
 
 [testenv:flake8]
 basepython = python3.10


### PR DESCRIPTION
Hello.
Thank you for the plugin, amazing plugin.
We have a usecase that is not covered by the current status: we would like the global number of attempted retries in a whole test run to be at max `--max-global-retries`. It allows to better control the degree of flakiness of the whole test suite.
I came out with this naive implementation, please review, I am all open to any modification.
Thank you