### PR TITLE
Fix: Prevent `ResourceWarning` when using `pytest-xdist`

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,10 +5,6 @@ on:
     branches: [ main ]
   pull_request: ~
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: true
-
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,6 +5,10 @@ on:
     branches: [ main ]
   pull_request: ~
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ config.ini
 credentials.ini
 dist/
 venv/
+.vscode/
+.python-version

--- a/pytest_retry/server.py
+++ b/pytest_retry/server.py
@@ -56,12 +56,7 @@ class ClientReporter(ReportHandler):
         self.sock.connect(("localhost", port))
 
     def __del__(self) -> None:
-        try:
-            self.sock.shutdown(socket.SHUT_WR)
-        except OSError:
-            pass
-        finally:
-            self.sock.close()
+        self.sock.close()
 
     def record_attempt(self, lines: list[str]) -> None:
         self.stream.writelines(lines)

--- a/tests/test_retry_plugin.py
+++ b/tests/test_retry_plugin.py
@@ -9,7 +9,10 @@ except ImportError:
 
 pytest_plugins = ["pytester"]
 
-xdist_test_marker = mark.skipif(not xdist_installed, reason="Only run if xdist is installed locally")
+xdist_test_marker = mark.skipif(
+    not xdist_installed,
+    reason="Only run if xdist is installed locally"
+)
 
 
 def check_outcome_field(outcomes, field_name, expected_value):
@@ -986,7 +989,7 @@ def test_xdist_resources_properly_closed_server_side(testdir):
 
         class MyWarning(Warning):
             pass
-        
+
         a = 0
         b = 0
 

--- a/tests/test_retry_plugin.py
+++ b/tests/test_retry_plugin.py
@@ -15,7 +15,8 @@ xdist_test_marker = mark.skipif(not xdist_installed, reason="Only run if xdist i
 def check_outcome_field(outcomes, field_name, expected_value):
     field_value = outcomes.get(field_name, 0)
     assert field_value == expected_value, (
-        f"outcomes.{field_name} has unexpected value. " f"Expected '{expected_value}' but got '{field_value}'"
+        f"outcomes.{field_name} has unexpected value. "
+        f"Expected '{expected_value}' but got '{field_value}'"
     )
 
 

--- a/tests/test_retry_plugin.py
+++ b/tests/test_retry_plugin.py
@@ -949,8 +949,6 @@ def test_stack_trace_depth_uses_verbosity_count(testdir, verbosity):
 def test_xdist_reporting_compatibility(testdir):
     testdir.makepyfile(
         """
-        import pytest
-
         a = 0
         b = 0
 
@@ -984,44 +982,26 @@ def test_xdist_resources_properly_closed_server_side(testdir):
 
     testdir.makepyfile(
         """
-        import pytest
-        import warnings
-
-        class MyWarning(Warning):
-            pass
-
         a = 0
         b = 0
 
-        def func_a_that_randomly_warns():
+        def test_flaky() -> None:
             global a
 
             a += 1
-            if a == 3:
-                warnings.warn("Test", category=MyWarning)
+            assert a == 3
 
-        def func_b_that_randomly_warns():
+        def test_moar_flaky() -> None:
             global b
 
             b += 1
-            if b == 2:
-                warnings.warn("Test", category=MyWarning)
-
-        def test_flaky_a():
-
-            with pytest.warns(MyWarning):
-                func_a_that_randomly_warns()
-
-        def test_flaky_b():
-
-            with pytest.warns(MyWarning):
-                func_b_that_randomly_warns()
+            assert b == 2
         """
     )
 
-    # The test MUST be run in a subprocess because the warnings appears
+    # The test MUST be run in a subprocess because the warnings appear
     # on pytest teardown
-    result = testdir.runpytest_subprocess("-n", "2", "--retries", "3", "-Werror")
+    result = testdir.runpytest_subprocess("-n", "2", "--retries", "3", "-W", "error")
 
     for line in result.errlines:
         assert "ResourceWarning" not in line

--- a/tox.ini
+++ b/tox.ini
@@ -1,21 +1,21 @@
 [tox]
 minversion = 3.9.0
-envlist = {py39, py310, py311}-{standard, xdist}, flake8, mypy
+envlist = py39, py310, py311, flake8, mypy
 isolated_build = true
 toxworkdir = {toxinidir}/../.tox
 
 [gh-actions]
 python =
-    3.9: py39-{standard,xdist}
-    3.10: py310-{standard,xdist}, mypy, flake8
-    3.11: py311-{standard,xdist}
+    3.9: py39
+    3.10: py310, mypy, flake8
+    3.11: py311
 
-[testenv:{py39,py310,py311}-{standard,xdist}]
+[testenv:{py39,py310,py311}]
 setenv =
     PYTHONPATH = {toxinidir}
 deps =
     -r{toxinidir}/dev-requirements.txt
-    xdist: pytest-xdist>=3.5,<4
+    pytest-xdist>=3.5,<4
 commands =
     pytest --basetemp={envtmpdir}
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.9.0
-envlist = py39, py310, py311, flake8, mypy
+envlist = py39, py310, py311, py312, flake8, mypy
 isolated_build = true
 toxworkdir = {toxinidir}/../.tox
 
@@ -9,12 +9,14 @@ python =
     3.9: py39
     3.10: py310, mypy, flake8
     3.11: py311
+    3.12: py312
 
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}
 deps =
     -r{toxinidir}/dev-requirements.txt
+    pytest-xdist
 commands =
     pytest --basetemp={envtmpdir}
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,22 +1,21 @@
 [tox]
 minversion = 3.9.0
-envlist = py39, py310, py311, py312, flake8, mypy
+envlist = {py39, py310, py311}-{standard, xdist}, flake8, mypy
 isolated_build = true
 toxworkdir = {toxinidir}/../.tox
 
 [gh-actions]
 python =
-    3.9: py39
-    3.10: py310, mypy, flake8
-    3.11: py311
-    3.12: py312
+    3.9: py39-{standard,xdist}
+    3.10: py310-{standard,xdist}, mypy, flake8
+    3.11: py311-{standard,xdist}
 
-[testenv]
+[testenv:{py39,py310,py311}-{standard,xdist}]
 setenv =
     PYTHONPATH = {toxinidir}
 deps =
     -r{toxinidir}/dev-requirements.txt
-    pytest-xdist
+    xdist: pytest-xdist
 commands =
     pytest --basetemp={envtmpdir}
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ setenv =
     PYTHONPATH = {toxinidir}
 deps =
     -r{toxinidir}/dev-requirements.txt
-    pytest-xdist>=3.5,<4
+    pytest-xdist>=3.6.1,<4
 commands =
     pytest --basetemp={envtmpdir}
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ setenv =
     PYTHONPATH = {toxinidir}
 deps =
     -r{toxinidir}/dev-requirements.txt
-    xdist: pytest-xdist
+    xdist: pytest-xdist>=3.5,<4
 commands =
     pytest --basetemp={envtmpdir}
 


### PR DESCRIPTION
Hello!
You told me in issue #26 to let you know if I noticed any problems, so here I am.

In an edge case which is very difficult to reproduce, the test suite could end with a small:
```
sys:1: ResourceWarning: unclosed <socket.socket fd=11, family=2, type=1, proto=0, laddr=('127.0.0.1', 33470), raddr=('127.0.0.1', 43621)>
```
And, after investigations, these are the sockets opened by the reporters which are not closed at the end of the process.