### PR TITLE
use verbosity count for trace limit rather than binary on off

### DIFF
--- a/pytest_retry/retry_plugin.py
+++ b/pytest_retry/retry_plugin.py
@@ -62,7 +62,7 @@ class RetryManager:
 
     def __init__(self) -> None:
         self.reporter: ReportHandler = OfflineReporter()
-        self.trace_limit: Optional[int] = -1
+        self.trace_limit: Optional[int] = 1
         self.node_stats: dict[str, dict] = {}
         self.messages = (
             " failed on attempt {attempt}! Retrying!\n\t",
@@ -298,9 +298,10 @@ def pytest_configure(config: pytest.Config) -> None:
         "that the test is retried only on those exceptions, or excluding those exceptions. "
         "Any statement which returns a bool can be used as a condition",
     )
-    if config.getoption("verbose"):
-        # if pytest config has -v enabled, then don't limit traceback length
-        retry_manager.trace_limit = None
+    verbosity = config.getoption("verbose")
+    if verbosity:
+        # set trace limit according to verbosity count, or unlimited if 5
+        retry_manager.trace_limit = verbosity if verbosity < 5 else None
     Defaults.configure(config)
     Defaults.add("FILTERED_EXCEPTIONS", config.hook.pytest_set_filtered_exceptions() or [])
     Defaults.add("EXCLUDED_EXCEPTIONS", config.hook.pytest_set_excluded_exceptions() or [])

--- a/tests/test_retry_plugin.py
+++ b/tests/test_retry_plugin.py
@@ -924,6 +924,22 @@ def test_conditional_flaky_marks_evaluate_correctly(testdir):
     assert_outcomes(result, passed=2, failed=1, retried=2)
 
 
+@mark.parametrize('verbosity', ['vv', 'vvv', 'vvvv'])
+def test_stack_trace_depth_uses_verbosity_count(testdir, verbosity):
+    testdir.makepyfile(
+        """
+        a = []
+        def test_eventually_passes():
+            a.append(1)
+            assert len(a) > 1
+        """
+    )
+    result = testdir.runpytest("--retries", "1", f"-{verbosity}")
+
+    assert_outcomes(result, passed=1, retried=1)
+    assert len([line for line in result.outlines if line.startswith('\t  File')]) == len(verbosity)
+
+
 @mark.skipif(xdist_installed is False, reason="Only run if xdist is installed locally")
 def test_xdist_reporting_compatability(testdir):
     testdir.makepyfile(


### PR DESCRIPTION
By default, pytest-retry records exceptions with a trace depth of 1. Pytest provides a verbosity option (note, Pytest only uses the verbosity command as an on/off switch, but records a counter for optional use by plugins). This change allows for increased control over trace length when verbose mode is enabled as previously, the trace limit would simply be disabled in this case. Now, trace depth should track to verbosity levels 1-4, with 5 producing the original unlimited trace behavior. 