### PR TITLE
Make default options setting less strict

### DIFF
--- a/pytest_retry/configs.py
+++ b/pytest_retry/configs.py
@@ -29,9 +29,8 @@ class _Defaults:
         raise ValueError("Defaults cannot be overwritten manually! Please use `configure()`")
 
     def add(self, name: str, value: Any) -> None:
-        if name in self._opts:
-            raise ValueError(f"{name} is already an existing default!")
-        self._opts[name] = value
+        if name not in self._opts:
+            self._opts[name] = value
 
     def load_ini(self, config: pytest.Config) -> None:
         """
@@ -46,7 +45,7 @@ class _Defaults:
         if config.getini("retries"):
             self.load_ini(config)
         for key in self._opts:
-            if (val := config.getoption(key.lower())) is not None:
+            if (val := config.getoption(key.lower(), None)) is not None:
                 self._opts[key] = val
 
 


### PR DESCRIPTION
When working with `pytester` on a plugin that depends on `pytest-retry`, I noticed that `_Defaults` may get initialized twice: once in the regular Pytest initialization, and again inside the `pytester` instance of it, causing its internal `_opts` dict to contain an already initialized set of defaults.

This PR makes `add` silently ignore values being added again, while also avoiding an exception being raised in `configure` if the value is not yet set:

```
-------------------------------------------------------------------------- Captured stderr call --------------------------------------------------------------------------
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File ".../lib/python3.13/site-packages/_pytest/config/__init__.py", line 1693, in getoption
INTERNALERROR>     val = getattr(self.option, name)
INTERNALERROR> AttributeError: 'Namespace' object has no attribute 'filtered_exceptions'
INTERNALERROR>
INTERNALERROR> The above exception was the direct cause of the following exception:
INTERNALERROR>
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File ".../lib/python3.13/site-packages/_pytest/main.py", line 279, in wrap_session
INTERNALERROR>     config._do_configure()
INTERNALERROR>     ~~~~~~~~~~~~~~~~~~~~^^
INTERNALERROR>   File ".../lib/python3.13/site-packages/_pytest/config/__init__.py", line 1118, in _do_configure
INTERNALERROR>     self.hook.pytest_configure.call_historic(kwargs=dict(config=self))
INTERNALERROR>     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File ".../lib/python3.13/site-packages/pluggy/_hooks.py", line 535, in call_historic
INTERNALERROR>     res = self._hookexec(self.name, self._hookimpls.copy(), kwargs, False)
INTERNALERROR>   File ".../lib/python3.13/site-packages/pluggy/_manager.py", line 120, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
INTERNALERROR>            ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File ".../lib/python3.13/site-packages/pluggy/_callers.py", line 139, in _multicall
INTERNALERROR>     raise exception.with_traceback(exception.__traceback__)
INTERNALERROR>   File ".../lib/python3.13/site-packages/pluggy/_callers.py", line 103, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File ".../lib/python3.13/site-packages/pytest_retry/retry_plugin.py", line 305, in pytest_configure
INTERNALERROR>     Defaults.configure(config)
INTERNALERROR>     ~~~~~~~~~~~~~~~~~~^^^^^^^^
INTERNALERROR>   File ".../lib/python3.13/site-packages/pytest_retry/configs.py", line 49, in configure
INTERNALERROR>     if (val := config.getoption(key.lower())) is not None:
INTERNALERROR>                ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
INTERNALERROR>   File ".../lib/python3.13/site-packages/_pytest/config/__init__.py", line 1704, in getoption
INTERNALERROR>     raise ValueError(f"no option named {name!r}") from e
INTERNALERROR> ValueError: no option named 'filtered_exceptions'
```